### PR TITLE
Add packaging for CentOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## in progress
 - Add package building for CentOS 6,7,8
+- Rename package to "owntracks-cli-publisher"
 
 ## 2020-01-12 0.8.0
 - add support for pledge(2) and unveil(2) in OpenBSD

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # ocli changelog
 
 ## in progress
+- Add package building for CentOS 6,7,8
 
 ## 2020-01-12 0.8.0
 - add support for pledge(2) and unveil(2) in OpenBSD

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## in progress
 - Add package building for CentOS 6,7,8
 - Rename package to "owntracks-cli-publisher"
+- Use version tag from "version.h".
 
 ## 2020-01-12 0.8.0
 - add support for pledge(2) and unveil(2) in OpenBSD

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -5,7 +5,7 @@
 #               configuration
 # ==========================================
 DIST_PATH := ./dist
-DIST_PACKAGE := owntracks-publisher
+DIST_PACKAGE := owntracks-cli-publisher
 
 
 # ==========================================

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -17,10 +17,17 @@ DIST_PACKAGE := owntracks-publisher
 # 	make build-debian-baseline arch=amd64 dist=buster version=0.1.0
 # 	make build-debian-baseline arch=armv7hf dist=stretch version=0.1.0
 #
+# 	make build-centos-baseline arch=amd64 dist=7 version=0.1.0
+# 	make build-centos-baseline arch=arm32v7 dist=7 version=0.1.0
+#
 
 build-debian-baseline: check-image-options
 	docker build --tag owntracks/baseline-$(dist)-$(arch):$(version) --build-arg BASE_IMAGE=balenalib/$(arch)-debian:$(dist)-build - < dockerfiles/Dockerfile.debian.baseline
 	docker tag owntracks/baseline-$(dist)-$(arch):$(version) owntracks/baseline-$(dist)-$(arch):latest
+
+build-centos-baseline: check-image-options
+	docker build --tag owntracks/baseline-centos$(dist)-$(arch):$(version) --build-arg BASE_IMAGE=$(arch)/centos:$(dist) - < dockerfiles/Dockerfile.centos.baseline
+	docker tag owntracks/baseline-centos$(dist)-$(arch):$(version) owntracks/baseline-centos$(dist)-$(arch):latest
 
 check-image-options:
 	@if test "$(arch)" = ""; then \
@@ -46,16 +53,36 @@ check-image-options:
 # Synopsis::
 #
 #    # Debian Buster amd64
-#    make debian-package arch=amd64 dist=buster version=0.7.0
+#    make debian-package arch=amd64 dist=buster pkgtype=deb version=0.7.0
 #
 #    # Debian Stretch armhf
-#    make debian-package arch=armhf dist=stretch version=0.7.0
+#    make debian-package arch=armhf dist=stretch pkgtype=deb version=0.7.0
+#
+#	 # CentOS 7
+#    make debian-package arch=amd64 dist=centos7 pkgtype=rpm version=0.7.0
 #
 
-debian-package:
-	$(MAKE) deb-build name=$(DIST_PACKAGE)
+# https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux
+# https://en.wikipedia.org/wiki/ANSI_escape_code
+YELLOW := \033[0;33m\033[1m
+NC := \033[0m
 
-deb-build: check-build-options
+debian-package:
+	$(eval name := $(DIST_PACKAGE))
+	$(eval package_name := $(name)_$(version)-1~$(dist)_$(arch).deb)
+	$(MAKE) pkg-build name=$(name) package_name=$(package_name)
+
+centos-package:
+ifeq ($(arch),armhf)
+	$(eval name_arch := arm32v7)
+else
+	$(eval name_arch := x86_64)
+endif
+	$(eval name := $(DIST_PACKAGE))
+	$(eval package_name := $(name)-$(version)-1~$(dist).$(name_arch).rpm)
+	$(MAKE) pkg-build name=$(name) package_name=$(package_name)
+
+pkg-build: check-build-options
 
 ifeq ($(arch),armhf)
 	$(eval build_arch := armv7hf)
@@ -63,21 +90,14 @@ else
 	$(eval build_arch := $(arch))
 endif
 
-	@# https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux
-	@# https://en.wikipedia.org/wiki/ANSI_escape_code
-	$(eval RED := "\033[0;31m")
-	$(eval YELLOW := \033[0;33m\033[1m)
-	$(eval NC := \033[0m)
-
 	@# Build Linux distribution package
-	@echo "Building package $(YELLOW)$(name)$(NC) version $(YELLOW)$(version)$(NC) for architecture $(YELLOW)$(arch)$(NC) and distribution $(YELLOW)$(dist)$(NC)."
+	@echo "Building $(YELLOW)$(pkgtype)$(NC) package $(YELLOW)$(name)$(NC) version $(YELLOW)$(version)$(NC) for architecture $(YELLOW)$(arch)$(NC) and distribution $(YELLOW)$(dist)$(NC)."
 
 	$(eval build_image := owntracks/baseline-$(dist)-$(build_arch):latest)
 	$(eval build_tag := owntracks/$(DIST_PACKAGE)-build-$(dist)-$(arch):$(version))
-	$(eval package_name := $(name)_$(version)-1~$(dist)_$(arch).deb)
 
 	@# Invoke the builder.
-	docker build --tag $(build_tag) --build-arg BASE_IMAGE=${build_image} --build-arg DISTRIBUTION=$(dist) --build-arg VERSION=$(version) --build-arg NAME=$(name) --file dockerfiles/Dockerfile.builder ..
+	docker build --tag $(build_tag) --build-arg BASE_IMAGE=${build_image} --build-arg DISTRIBUTION=$(dist) --build-arg PKGTYPE=$(pkgtype) --build-arg VERSION=$(version) --build-arg NAME=$(name) --file dockerfiles/Dockerfile.builder ..
 
 
 	@echo "Harvesting package $(YELLOW)$(package_name)$(NC) from Docker container to directory $(YELLOW)$(DIST_PATH)$(NC)."
@@ -103,6 +123,10 @@ check-build-options:
 	fi
 	@if test "$(dist)" = ""; then \
 		echo "ERROR: 'dist' not set"; \
+		exit 1; \
+	fi
+	@if test "$(pkgtype)" = ""; then \
+		echo "ERROR: 'pkgtype' not set"; \
 		exit 1; \
 	fi
 	@if test "$(name)" = ""; then \

--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -4,8 +4,10 @@
 # ==========================================
 #               configuration
 # ==========================================
-DIST_PATH := ./dist
-DIST_PACKAGE := owntracks-cli-publisher
+PACKAGE_PATH    = ./dist
+PACKAGE_NAME    = owntracks-cli-publisher
+PACKAGE_VERSION = $(shell cat ../version.h | sed -e 's/\#define VERSION //' | tr -d '"\n')
+
 
 
 # ==========================================
@@ -53,13 +55,13 @@ check-image-options:
 # Synopsis::
 #
 #    # Debian Buster amd64
-#    make debian-package arch=amd64 dist=buster pkgtype=deb version=0.7.0
+#    make debian-package arch=amd64 dist=buster pkgtype=deb
 #
 #    # Debian Stretch armhf
-#    make debian-package arch=armhf dist=stretch pkgtype=deb version=0.7.0
+#    make debian-package arch=armhf dist=stretch pkgtype=deb
 #
 #	 # CentOS 7
-#    make debian-package arch=amd64 dist=centos7 pkgtype=rpm version=0.7.0
+#    make debian-package arch=amd64 dist=centos7 pkgtype=rpm
 #
 
 # https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux
@@ -68,8 +70,8 @@ YELLOW := \033[0;33m\033[1m
 NC := \033[0m
 
 debian-package:
-	$(eval name := $(DIST_PACKAGE))
-	$(eval package_name := $(name)_$(version)-1~$(dist)_$(arch).deb)
+	$(eval name := $(PACKAGE_NAME))
+	$(eval package_name := $(name)_$(PACKAGE_VERSION)-1~$(dist)_$(arch).deb)
 	$(MAKE) pkg-build name=$(name) package_name=$(package_name)
 
 centos-package:
@@ -78,8 +80,8 @@ ifeq ($(arch),armhf)
 else
 	$(eval name_arch := x86_64)
 endif
-	$(eval name := $(DIST_PACKAGE))
-	$(eval package_name := $(name)-$(version)-1~$(dist).$(name_arch).rpm)
+	$(eval name := $(PACKAGE_NAME))
+	$(eval package_name := $(name)-$(PACKAGE_VERSION)-1~$(dist).$(name_arch).rpm)
 	$(MAKE) pkg-build name=$(name) package_name=$(package_name)
 
 pkg-build: check-build-options
@@ -91,29 +93,29 @@ else
 endif
 
 	@# Build Linux distribution package
-	@echo "Building $(YELLOW)$(pkgtype)$(NC) package $(YELLOW)$(name)$(NC) version $(YELLOW)$(version)$(NC) for architecture $(YELLOW)$(arch)$(NC) and distribution $(YELLOW)$(dist)$(NC)."
+	@echo "Building $(YELLOW)$(pkgtype)$(NC) package $(YELLOW)$(name)$(NC) version $(YELLOW)$(PACKAGE_VERSION)$(NC) for architecture $(YELLOW)$(arch)$(NC) and distribution $(YELLOW)$(dist)$(NC)."
 
 	$(eval build_image := owntracks/baseline-$(dist)-$(build_arch):latest)
-	$(eval build_tag := owntracks/$(DIST_PACKAGE)-build-$(dist)-$(arch):$(version))
+	$(eval build_tag := owntracks/$(PACKAGE_NAME)-build-$(dist)-$(arch):$(PACKAGE_VERSION))
 
 	@# Invoke the builder.
-	docker build --tag $(build_tag) --build-arg BASE_IMAGE=${build_image} --build-arg DISTRIBUTION=$(dist) --build-arg PKGTYPE=$(pkgtype) --build-arg VERSION=$(version) --build-arg NAME=$(name) --file dockerfiles/Dockerfile.builder ..
+	docker build --tag $(build_tag) --build-arg BASE_IMAGE=${build_image} --build-arg DISTRIBUTION=$(dist) --build-arg PKGTYPE=$(pkgtype) --build-arg VERSION=$(PACKAGE_VERSION) --build-arg NAME=$(name) --file dockerfiles/Dockerfile.builder ..
 
 
-	@echo "Harvesting package $(YELLOW)$(package_name)$(NC) from Docker container to directory $(YELLOW)$(DIST_PATH)$(NC)."
+	@echo "Harvesting package $(YELLOW)$(package_name)$(NC) from Docker container to directory $(YELLOW)$(PACKAGE_PATH)$(NC)."
 
 	@# Spin up container.
 	@docker container rm -f finalize; true
 	docker container create --name finalize $(build_tag)
 
 	@# Copy .deb file from Docker container to working tree.
-	mkdir -p $(DIST_PATH)
-	docker container cp finalize:/sources/dist/$(package_name) $(DIST_PATH)
+	mkdir -p $(PACKAGE_PATH)
+	docker container cp finalize:/sources/dist/$(package_name) $(PACKAGE_PATH)
 
 	@# Destroy container.
 	docker container rm -f finalize
 
-	@echo "Enjoy your package at $(YELLOW)$(DIST_PATH)/$(package_name)$(NC)."
+	@echo "Enjoy your package at $(YELLOW)$(PACKAGE_PATH)/$(package_name)$(NC)."
 
 
 check-build-options:
@@ -133,10 +135,6 @@ check-build-options:
 		echo "ERROR: 'name' not set"; \
 		exit 1; \
 	fi
-	@if test "$(version)" = ""; then \
-		echo "ERROR: 'version' not set"; \
-		exit 1; \
-	fi
 
 
 # ==========================================
@@ -148,17 +146,17 @@ check-build-options:
 # Synopsis::
 #
 #    # Debian amd64
-#    make publish-package arch=amd64 dist=buster version=0.7.0
+#    make publish-package arch=amd64 dist=buster
 #
 #    # Debian armhf
-#    make debian-package arch=armhf dist=stretch version=0.7.0
+#    make debian-package arch=armhf dist=stretch
 #
 
 $(eval github-release := ./bin/github-release)
 
 publish-package: check-github-release check-publish-options
 
-	$(eval package_file := $(DIST_PATH)/$(DIST_PACKAGE)_$(version)-1~$(dist)_$(arch).deb)
+	$(eval package_file := $(PACKAGE_PATH)/$(PACKAGE_NAME)_$(PACKAGE_VERSION)-1~$(dist)_$(arch).deb)
 
 	@echo "Uploading release artefact $(package_file) to GitHub"
 
@@ -166,11 +164,11 @@ publish-package: check-github-release check-publish-options
 	@#$(github-release) info --user owntracks --repo ocli
 
     # Create Release.
-	$(github-release) release --user owntracks --repo ocli --tag $(version) || true
+	$(github-release) release --user owntracks --repo ocli --tag $(PACKAGE_VERSION) || true
 	@# --draft
 
     # Upload artifact.
-	$(github-release) upload --user owntracks --repo ocli --tag $(version) --name $(notdir $(package_file)) --file $(package_file) --replace
+	$(github-release) upload --user owntracks --repo ocli --tag $(PACKAGE_VERSION) --name $(notdir $(package_file)) --file $(package_file) --replace
 
 check-publish-options:
 	@if test "$(arch)" = ""; then \
@@ -179,10 +177,6 @@ check-publish-options:
 	fi
 	@if test "$(dist)" = ""; then \
 		echo "ERROR: 'dist' not set"; \
-		exit 1; \
-	fi
-	@if test "$(version)" = ""; then \
-		echo "ERROR: 'version' not set"; \
 		exit 1; \
 	fi
 

--- a/packaging/README.rst
+++ b/packaging/README.rst
@@ -1,5 +1,5 @@
 ##############################################
-Build, package and publish owntracks-publisher
+Build, package and publish owntracks-cli-publisher
 ##############################################
 
 .. highlight:: bash
@@ -9,7 +9,7 @@ Build, package and publish owntracks-publisher
 Introduction
 ************
 This outlines the Makefile targets of a convenient
-packaging subsystem for ocli / owntracks-publisher.
+packaging subsystem for owntracks-cli-publisher.
 
 Currently, this is focused on Debian and CentOS packages
 but might be extended in the future.
@@ -65,7 +65,7 @@ Prepare baseline images for ``armhf`` architecture::
 *****
 Build
 *****
-Build ``owntracks-publisher`` package for ``amd64`` architecture::
+Build ``owntracks-cli-publisher`` package for ``amd64`` architecture::
 
     # Debian stretch amd64
     make debian-package arch=amd64 dist=stretch pkgtype=deb version=0.7.0
@@ -80,7 +80,7 @@ Build ``owntracks-publisher`` package for ``amd64`` architecture::
     make centos-package arch=amd64 dist=centos8 pkgtype=rpm version=0.7.0
 
 
-Build ``owntracks-publisher`` package for ``armhf`` architecture::
+Build ``owntracks-cli-publisher`` package for ``armhf`` architecture::
 
     # Debian stretch armhf
     make debian-package arch=armhf dist=stretch pkgtype=deb version=0.7.0

--- a/packaging/README.rst
+++ b/packaging/README.rst
@@ -68,22 +68,22 @@ Build
 Build ``owntracks-cli-publisher`` package for ``amd64`` architecture::
 
     # Debian stretch amd64
-    make debian-package arch=amd64 dist=stretch pkgtype=deb version=0.7.0
+    make debian-package arch=amd64 dist=stretch pkgtype=deb
 
     # Debian buster amd64
-    make debian-package arch=amd64 dist=buster pkgtype=deb version=0.7.0
+    make debian-package arch=amd64 dist=buster pkgtype=deb
 
     # CentOS 7 amd64
-    make centos-package arch=amd64 dist=centos7 pkgtype=rpm version=0.7.0
+    make centos-package arch=amd64 dist=centos7 pkgtype=rpm
 
     # CentOS 8 amd64
-    make centos-package arch=amd64 dist=centos8 pkgtype=rpm version=0.7.0
+    make centos-package arch=amd64 dist=centos8 pkgtype=rpm
 
 
 Build ``owntracks-cli-publisher`` package for ``armhf`` architecture::
 
     # Debian stretch armhf
-    make debian-package arch=armhf dist=stretch pkgtype=deb version=0.7.0
+    make debian-package arch=armhf dist=stretch pkgtype=deb
 
 
 *******
@@ -95,10 +95,10 @@ Publish package to GitHub::
     export GITHUB_TOKEN=642ff7c47b1697a79ab7f105e1d79f054d0bbeef
 
     # Debian buster amd64
-    make publish-package arch=amd64 dist=buster version=0.7.0
+    make publish-package arch=amd64 dist=buster
 
     # Debian stretch armhf
-    make publish-package arch=armhf dist=stretch version=0.7.0
+    make publish-package arch=armhf dist=stretch
 
 
 *****

--- a/packaging/README.rst
+++ b/packaging/README.rst
@@ -11,8 +11,8 @@ Introduction
 This outlines the Makefile targets of a convenient
 packaging subsystem for ocli / owntracks-publisher.
 
-Currently, this is focused on Debian packages but
-might be extended in the future.
+Currently, this is focused on Debian and CentOS packages
+but might be extended in the future.
 
 Three steps are required to successfully build packages.
 
@@ -26,6 +26,7 @@ Three steps are required to successfully build packages.
 3. Publish:
    Upload package file to GitHub release page.
 
+
 *****
 Usage
 *****
@@ -37,25 +38,52 @@ First, go to the "packaging" directory::
 *****
 Setup
 *****
-Prepare baseline images for both amd64 and armhf architectures::
+Prepare baseline images for ``amd64`` architecture::
+
+    # Debian stretch amd64
+    make build-debian-baseline arch=amd64 dist=stretch version=0.1.0
 
     # Debian buster amd64
     make build-debian-baseline arch=amd64 dist=buster version=0.1.0
 
+    # CentOS 7 amd64
+    make build-centos-baseline arch=amd64 dist=7 version=0.1.0
+
+    # CentOS 8 amd64
+    make build-centos-baseline arch=amd64 dist=8 version=0.1.0
+
+
+Prepare baseline images for ``armhf`` architecture::
+
     # Debian stretch armhf
     make build-debian-baseline arch=armv7hf dist=stretch version=0.1.0
+
+    # TODO: make build-centos-baseline arch=arm32v7 dist=7 version=0.1.0
+    # TODO: make build-centos-baseline arch=arm64v8 dist=7 version=0.1.0
 
 
 *****
 Build
 *****
-Build "owntracks-publisher" package::
+Build ``owntracks-publisher`` package for ``amd64`` architecture::
+
+    # Debian stretch amd64
+    make debian-package arch=amd64 dist=stretch pkgtype=deb version=0.7.0
 
     # Debian buster amd64
-    make debian-package arch=amd64 dist=buster version=0.7.0
+    make debian-package arch=amd64 dist=buster pkgtype=deb version=0.7.0
+
+    # CentOS 7 amd64
+    make centos-package arch=amd64 dist=centos7 pkgtype=rpm version=0.7.0
+
+    # CentOS 8 amd64
+    make centos-package arch=amd64 dist=centos8 pkgtype=rpm version=0.7.0
+
+
+Build ``owntracks-publisher`` package for ``armhf`` architecture::
 
     # Debian stretch armhf
-    make debian-package arch=armhf dist=stretch version=0.7.0
+    make debian-package arch=armhf dist=stretch pkgtype=deb version=0.7.0
 
 
 *******
@@ -71,3 +99,17 @@ Publish package to GitHub::
 
     # Debian stretch armhf
     make publish-package arch=armhf dist=stretch version=0.7.0
+
+
+*****
+Notes
+*****
+These Docker images are used for creating the baseline images:
+
+- https://hub.docker.com/r/amd64/debian (todo)
+- https://hub.docker.com/r/arm32v7/debian (todo)
+- https://hub.docker.com/r/arm64v8/debian (todo)
+
+- https://hub.docker.com/r/amd64/centos
+- https://hub.docker.com/r/arm32v7/centos
+- https://hub.docker.com/r/arm64v8/centos

--- a/packaging/builder/fpm-package
+++ b/packaging/builder/fpm-package
@@ -4,12 +4,14 @@
 ##
 # Synopsis::
 #
-#   fpm-package owntracks-publisher buster 0.7.0
+#   fpm-package owntracks-publisher buster deb 0.7.0
+#   fpm-package owntracks-publisher centos8 rpm 0.7.0
 #
 
 NAME=$1
 DISTRIBUTION=$2
-VERSION=$3
+PKGTYPE=$3
+VERSION=$4
 
 echo "Building package ${NAME}-${VERSION} for ${DISTRIBUTION}"
 
@@ -17,7 +19,7 @@ mkdir ./dist
 
 # Build Debian package
 fpm \
-    -s dir -t deb \
+    -s dir -t ${PKGTYPE} \
     \
     --name ${NAME} \
     --version ${VERSION} \

--- a/packaging/builder/fpm-package
+++ b/packaging/builder/fpm-package
@@ -1,11 +1,11 @@
 #!/bin/bash
 #
-# Packaging the "owntracks-publisher" using "fpm".
+# Packaging the "owntracks-cli-publisher" using "fpm".
 ##
 # Synopsis::
 #
-#   fpm-package owntracks-publisher buster deb 0.7.0
-#   fpm-package owntracks-publisher centos8 rpm 0.7.0
+#   fpm-package owntracks-cli-publisher buster deb 0.7.0
+#   fpm-package owntracks-cli-publisher centos8 rpm 0.7.0
 #
 
 NAME=$1
@@ -34,11 +34,11 @@ fpm \
 	--license "GPL 2" \
 	--deb-changelog CHANGES.md \
 	--deb-meta-file README.md \
-	--description "OwnTracks publisher" \
+	--description "OwnTracks CLI publisher" \
 	--url "https://github.com/owntracks/ocli" \
     \
     --package ./dist/ \
-    --deb-default ./packaging/etc/owntracks-publisher.env \
+    --deb-default ./packaging/etc/owntracks-cli-publisher.env \
     --before-install ./packaging/scripts/before-install \
     --after-install ./packaging/scripts/after-install \
     --before-remove ./packaging/scripts/before-remove \
@@ -46,7 +46,7 @@ fpm \
     --force \
     ./ocli=/usr/local/bin/ocli \
     ./ocli.1=/usr/local/man/man1/ocli.1 \
-    ./packaging/systemd/owntracks-publisher.service=/usr/lib/systemd/system/owntracks-publisher.service
+    ./packaging/systemd/owntracks-cli-publisher.service=/usr/lib/systemd/system/owntracks-cli-publisher.service
 
 
 # Optionally

--- a/packaging/dockerfiles/Dockerfile.builder
+++ b/packaging/dockerfiles/Dockerfile.builder
@@ -1,18 +1,10 @@
 ARG BASE_IMAGE
 
 
-# ===========================
-# Customize build environment
-# ===========================
-FROM ${BASE_IMAGE} AS build-environment
-
-RUN apt-get install --yes --no-install-recommends libgps-dev libmosquitto-dev
-
-
 # ===============
 # Acquire sources
 # ===============
-FROM build-environment AS acquire-sources
+FROM ${BASE_IMAGE} AS acquire-sources
 ARG SOURCES=/sources
 COPY . $SOURCES
 
@@ -40,9 +32,10 @@ FROM build-program AS package-program
 ENV TMPDIR=/var/tmp
 
 ARG DISTRIBUTION
+ARG PKGTYPE
 ARG VERSION
 ARG NAME
 ARG SOURCES=/sources
 
 WORKDIR $SOURCES
-RUN ./packaging/builder/fpm-package "${NAME}" "${DISTRIBUTION}" "${VERSION}"
+RUN ./packaging/builder/fpm-package "${NAME}" "${DISTRIBUTION}" "${PKGTYPE}" "${VERSION}"

--- a/packaging/dockerfiles/Dockerfile.centos.baseline
+++ b/packaging/dockerfiles/Dockerfile.centos.baseline
@@ -1,0 +1,102 @@
+ARG BASE_IMAGE
+
+
+# =========================
+# Derive from superbaseline
+# =========================
+FROM ${BASE_IMAGE} AS centos-base
+
+RUN yum install -y deltarpm; exit 0
+RUN yum update -y
+
+
+# ===========
+# Build tools
+# ===========
+FROM centos-base AS centos-build
+
+# Build foundation and header files
+RUN yum install -y \
+    gcc gcc-c++ make pkgconfig
+
+
+# ===============
+# Packaging tools
+# ===============
+FROM centos-build AS centos-fpm
+
+# FPM
+RUN yum install -y \
+    ruby ruby-devel rubygems rpm-build
+
+RUN echo && echo "Installing fpm. This might take a while." && echo
+
+# CentOS 6: Ruby is too old, so install "fpm" within "rvm" environment.
+# https://github.com/jordansissel/fpm/issues/1192#issuecomment-466385257
+RUN \
+    grep 'release 6' /etc/centos-release || exit 0 && ( \
+        yum install -y curl libyaml && \
+	    curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import - && \
+	    curl -L get.rvm.io | bash -s stable && \
+        # source /etc/profile.d/rvm.sh \
+        export rvm=/usr/local/rvm/bin/rvm && \
+	    $rvm reload && \
+	    $rvm install 2.3.1 && \
+	    $rvm all do gem install fpm --version 1.11.0 && \
+	    ln -s /usr/local/rvm/gems/ruby-2.3.1/wrappers/fpm /usr/local/bin/fpm \
+    )
+
+# CentOS 7,8
+RUN \
+    grep -v 'release 6' /etc/centos-release || exit 0 && ( \
+        gem install fpm --version 1.11.0 \
+    )
+
+
+# =========================
+# Prepare build environment
+# =========================
+FROM centos-fpm
+
+RUN yum install -y openssl-devel libuuid-devel wget
+
+# Install PUIAS and OKey repositories in order
+# to install "scons" for building "gpsd".
+RUN \
+    grep 'release 6' /etc/centos-release || exit 0 && ( \
+        wget https://download-ib01.fedoraproject.org/pub/epel/6/x86_64/Packages/e/epel-release-6-8.noarch.rpm && \
+        wget http://repo.okay.com.mx/centos/6/x86_64/release//okay-release-1-3.el6.noarch.rpm && \
+        rpm -i *.rpm && \
+        yum install -y python-devel scons \
+    )
+
+RUN \
+    grep 'release 7' /etc/centos-release || exit 0 && ( \
+        wget https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-12.noarch.rpm && \
+        wget http://repo.okay.com.mx/centos/7/x86_64/release//okay-release-1-3.el7.noarch.rpm && \
+        rpm -i *.rpm && \
+        yum install -y python-devel scons \
+    )
+
+RUN \
+    grep 'release 8' /etc/centos-release || exit 0 && ( \
+        wget https://download-ib01.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/e/epel-release-8-8.el8.noarch.rpm && \
+        wget http://repo.okay.com.mx/centos/8/x86_64/release//okay-release-1-3.el8.noarch.rpm && \
+        rpm -i *.rpm && \
+        yum install -y python3-devel scons \
+    )
+
+
+# Install "gpsd".
+RUN \
+    wget https://gitlab.com/gpsd/gpsd/-/archive/release-3.19/gpsd-release-3.19.tar.gz && \
+    tar -xzf gpsd-release-3.19.tar.gz && \
+    cd gpsd-release-3.19 && \
+    scons && scons install
+
+# Install "mosquitto".
+RUN \
+    wget https://mosquitto.org/files/source/mosquitto-1.5.9.tar.gz && \
+    tar -xzf mosquitto-1.5.9.tar.gz && \
+    cd mosquitto-1.5.9 && \
+    make && make install

--- a/packaging/dockerfiles/Dockerfile.debian.baseline
+++ b/packaging/dockerfiles/Dockerfile.debian.baseline
@@ -1,8 +1,17 @@
 ARG BASE_IMAGE
 
-FROM ${BASE_IMAGE} AS debian-build
 
+# =========================
+# Derive from superbaseline
+# =========================
+FROM ${BASE_IMAGE} AS debian-base
 RUN apt-get update && apt-get upgrade
+
+
+# ===========
+# Build tools
+# ===========
+FROM debian-base AS debian-build
 
 # Build foundation and header files
 RUN apt-get install --yes --no-install-recommends \
@@ -10,9 +19,21 @@ RUN apt-get install --yes --no-install-recommends \
     build-essential pkg-config libssl-dev
 
 
-FROM debian-build
+# ===============
+# Packaging tools
+# ===============
+FROM debian-build AS debian-fpm
 
 # FPM
+RUN echo && echo "Installing fpm. This might take a while." && echo
 RUN apt-get install --yes --no-install-recommends \
     ruby ruby-dev && \
     gem install fpm --version 1.11.0
+
+
+# ===========================
+# Customize build environment
+# ===========================
+FROM debian-fpm
+
+RUN apt-get install --yes --no-install-recommends libgps-dev libmosquitto-dev

--- a/packaging/etc/owntracks-cli-publisher.env
+++ b/packaging/etc/owntracks-cli-publisher.env
@@ -1,6 +1,6 @@
-# ==============================================
-# Custom startup options for owntracks-publisher
-# ==============================================
+# ==================================================
+# Custom startup options for owntracks-cli-publisher
+# ==================================================
 
 # this file is read by the systemd unit
 

--- a/packaging/scripts/after-install
+++ b/packaging/scripts/after-install
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-systemctl reenable owntracks-publisher
+systemctl reenable owntracks-cli-publisher
 
 # Don't autostart. User will have to configure it first.
-#systemctl restart owntracks-publisher
+#systemctl restart owntracks-cli-publisher
 
 echo
-echo "1. Please adjust configuration: /etc/default/owntracks-publisher.env"
-echo "2. Start daemon: systemctl start owntracks-publisher"
+echo "1. Please adjust configuration: /etc/default/owntracks-cli-publisher.env"
+echo "2. Start daemon: systemctl start owntracks-cli-publisher"
 echo "3. Watch logfile: /tmp/owntracks-fix.log"
 echo "4. Subscribe to MQTT broker and see what's going on there"
 echo

--- a/packaging/scripts/before-remove
+++ b/packaging/scripts/before-remove
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 # Stop and disable the service.
-systemctl stop owntracks-publisher
-systemctl disable owntracks-publisher
+systemctl stop owntracks-cli-publisher
+systemctl disable owntracks-cli-publisher

--- a/packaging/systemd/owntracks-cli-publisher.service
+++ b/packaging/systemd/owntracks-cli-publisher.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Type=simple
-EnvironmentFile=/etc/default/owntracks-publisher.env
+EnvironmentFile=/etc/default/owntracks-cli-publisher.env
 ExecStart=/usr/local/bin/ocli
 Restart=always
 RestartSec=60
@@ -14,4 +14,4 @@ Group=owntracks
 
 [Install]
 WantedBy=multi-user.target
-Alias=owntracks-publisher.service
+Alias=owntracks-cli-publisher.service


### PR DESCRIPTION
## Introduction
Within #4, @jpmens 
> smelled blood, and I now want that magical Makefile all over the show, and can we add CentOS? :-)

## About
This adds packaging for CentOS 6,7,8. Further, packaging now takes the version tag from the `version.h` file.

What I can tell is that I haven't been able to make `packaging/etc/owntracks-cli-publisher.env` part of the `.rpm` package yet. So, that detail should go into the documentation somehow. Can I humbly ask you to test the package and add this to the documentation, @jpmens?

## Preview
![image](https://user-images.githubusercontent.com/453543/72482790-2e3a9200-37ff-11ea-9838-5a60b80535e9.png)
