### PR TITLE
Broker authentication support

### DIFF
--- a/owntracks-cli-publisher.1
+++ b/owntracks-cli-publisher.1
@@ -124,6 +124,10 @@ the short host name.
 The MQTT host defaults to \fClocalhost\fR.
 .IP \fCMQTT_PORT\fR 1i
 The MQTT port is \fC1883\fR.
+.IP \fCMQTT_USER\fR 1i
+The username to use to authenticate with the MQTT broker.
+.IP \fCMQTT_PASS\fR 1i
+The password to use to authenticate with the MQTT broker.
 .IP \fCOCLI_CLIENTID\fR 1i
 The MQTT clientId is set to \fC"ocli-\fIusername\fR\fC-\fIhostname\fR\fC"\fR.
 .IP \fCGPSD_HOST\fR 1i
@@ -147,7 +151,7 @@ will publish a location position defaults to 0 meters and can be changed dynamic
 .IP \fCOCLI_CACERT\fR 1i
 The path to a PEM-encoded CA certificate which
 .B ocli
-uses to enable TLS/SSL.It is likely that the default MQTT port will need to be changed at the same time.
+uses to enable TLS/SSL. It is likely that the default MQTT port will need to be changed at the same time.
 .\"-----------------------------------------------------------
 .SH BUGS
 Very likely.

--- a/owntracks-cli-publisher.c
+++ b/owntracks-cli-publisher.c
@@ -546,6 +546,8 @@ int main(int argc, char **argv)
 	char *gpsd_host = "localhost", *gpsd_port = DEFAULT_GPSD_PORT;
 	char *mqtt_host = "localhost";
 	short mqtt_port = 1883;
+	char *mqtt_user = NULL;
+	char *mqtt_pass = NULL;
 	struct udata udata, *ud = &udata;
 	char hostname[BUFSIZ], *h, *username;
 	JsonNode *jo;
@@ -595,6 +597,12 @@ int main(int argc, char **argv)
 	if ((p = getenv("MQTT_PORT")) != NULL) {
 		mqtt_port = atoi(p) < 1 ? 1883 : atoi(p);
 	}
+
+	if ((p = getenv("MQTT_USER")) != NULL)
+		mqtt_user = strdup(p);
+
+	if ((p = getenv("MQTT_PASS")) != NULL)
+		mqtt_pass = strdup(p);
 
 	if ((p = getenv("OCLI_CACERT")) != NULL) {
 		cacert = strdup(p);
@@ -700,8 +708,13 @@ int main(int argc, char **argv)
 			);
 	}
 
-
-
+	if (mqtt_user != NULL) {
+		mosquitto_username_pw_set(ud->mosq,
+			mqtt_user,
+			mqtt_pass
+			);
+	}
+	
 	/* Create payload for LWT consisting of starting timestamp */
 	jo = json_mkobject();
 


### PR DESCRIPTION
Introduces optional support for authenticating with the MQTT broker using `MQTT_USER` and `MQTT_PASS`.